### PR TITLE
Book-editing and RTL language input

### DIFF
--- a/app/assets/javascripts/components/Book.es6.jsx
+++ b/app/assets/javascripts/components/Book.es6.jsx
@@ -112,6 +112,8 @@ class Book extends React.Component {
 
   onSaveBookClick() {
     this.state.errors = [];
+    this.state.book.source_language = this.state.book.source_language_draft;
+    this.state.book.target_language = this.state.book.target_language_draft;    
     if (this.state.book.title && this.state.book.source_language && this.state.book.target_language) {
       $.ajax({
         url: '/books/' + this.state.book.id,
@@ -153,7 +155,13 @@ class Book extends React.Component {
   }
 
   toggleEditingBookState() {
-    this.setState({ isEditingBook: true });
+    const modBook = this.state.book;
+    modBook.source_language_draft = modBook.source_language;
+    modBook.target_language_draft = modBook.target_language;
+    this.setState({
+      isEditingBook: true,
+      book: modBook
+    });
   }
 
   cancelEditingBookState() {
@@ -555,9 +563,9 @@ class Book extends React.Component {
       return (
         <input
           className="new isEditing"
-          name="source_language"
+          name="source_language_draft"
           onChange={this.onInputChange}
-          value={this.state.book.source_language}
+          value={this.state.book.source_language_draft}
         />
       );
     }
@@ -573,9 +581,9 @@ class Book extends React.Component {
       return (
         <input
           className="new isEditing"
-          name="target_language"
+          name="target_language_draft"
           onChange={this.onInputChange}
-          value={this.state.book.target_language}
+          value={this.state.book.target_language_draft}
         />
       );
     }

--- a/app/assets/javascripts/components/Book.es6.jsx
+++ b/app/assets/javascripts/components/Book.es6.jsx
@@ -113,7 +113,9 @@ class Book extends React.Component {
   onSaveBookClick() {
     this.state.errors = [];
     this.state.book.source_language = this.state.book.source_language_draft;
-    this.state.book.target_language = this.state.book.target_language_draft;    
+    this.state.book.target_language = this.state.book.target_language_draft;
+    this.state.book.title = this.state.book.title_draft;
+    this.state.book.description = this.state.book.description_draft;
     if (this.state.book.title && this.state.book.source_language && this.state.book.target_language) {
       $.ajax({
         url: '/books/' + this.state.book.id,
@@ -156,6 +158,8 @@ class Book extends React.Component {
 
   toggleEditingBookState() {
     const modBook = this.state.book;
+    modBook.title_draft = modBook.title;
+    modBook.description_draft = modBook.description;
     modBook.source_language_draft = modBook.source_language;
     modBook.target_language_draft = modBook.target_language;
     this.setState({
@@ -285,10 +289,10 @@ class Book extends React.Component {
     if (this.state.isEditingBook) {
       return (
         <input
-          name="title"
+          name="title_draft"
           className="title new isEditing"
           onChange={this.onInputChange}
-          value={this.state.book.title}
+          value={this.state.book.title_draft}
         />
       );
     }
@@ -532,9 +536,9 @@ class Book extends React.Component {
           <textarea
             rows="4"
             className="description new isEditing"
-            name="description"
+            name="description_draft"
             onChange={this.onInputChange}
-            value={this.state.book.description}
+            value={this.state.book.description_draft}
           />
         );
       } else {
@@ -546,9 +550,9 @@ class Book extends React.Component {
           <textarea
             rows="4"
             className="description new isEditing"
-            name="description"
+            name="description_draft"
             onChange={this.onInputChange}
-            value={this.state.book.description}
+            value={this.state.book.description_draft}
             placeholder="Describe the contents of your book,
             Ex: A collection of useful phrases in Laputa, a Swiftian
             language spoken in Balnibarbi and a number of other islands..."

--- a/app/assets/javascripts/components/Dictionary.es6.jsx
+++ b/app/assets/javascripts/components/Dictionary.es6.jsx
@@ -375,6 +375,7 @@ class Dictionary extends React.Component {
           onChange={this.onTargetPhraseChange}
           className="targetPhrase input"
           type="text"
+          dir="auto"
           placeholder="Target" />
         <button className="savePhrase"> Save </button>
       </form>


### PR DESCRIPTION
Fix for one bug which was previously reported (#125) - when I'm editing the book, store title, description, and languages in a draft state

It also fixes one bug which wasn't yet reported (right-to-left language input on a text input should be right-justified, fixed by adding dir=auto).  I'd like to fix up more areas related to RTL support in the future