### PR TITLE
Add 'https://' to Heroku App URL to make it absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The app is intended to be used via the UI by any person with access to a modern 
 
 [Video Demo](https://youtu.be/rt-NigJJCgI)
 
-[Live App](poly-wikitongues.herokuapp.com)
+[Live App](https://poly-wikitongues.herokuapp.com)
 <!-- App screenshots -->
 
 #Feature Map


### PR DESCRIPTION
I noticed that clicking this link from the README is broken because it is currently relative, not absolute.