### PR TITLE
Add validation of username length and reduce fontsize for longer names in userInformation

### DIFF
--- a/app/assets/javascripts/components/Profile.es6.jsx
+++ b/app/assets/javascripts/components/Profile.es6.jsx
@@ -207,6 +207,7 @@ class Profile extends React.Component {
     const createdYear = createdDate.getUTCFullYear();
     const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
     const createdMonth = months[createdDate.getMonth()];
+    const username = this.props.userData.username;
 
     return (
       <div className="container">
@@ -224,7 +225,9 @@ class Profile extends React.Component {
               <img src={`https://www.gravatar.com/avatar/${this.props.hashedEmail}?s=200`} width="200px" height="200px"/>
               <span className="tooltip">?</span>
               <span className="details">
-                <h2>{this.props.userData.username}</h2>
+                <h2 className={username.length > 9 ? "smallText" : ""}>
+                  {username}
+                </h2>
                 <p>Joined {createdMonth} {createdYear}</p>
                 {this.renderEditButton()}
               </span>

--- a/app/assets/stylesheets/nav.styl
+++ b/app/assets/stylesheets/nav.styl
@@ -44,7 +44,6 @@ nav
 
   .loggedIn
     height 33px
-    width 140px
     float right
     overflow hidden
 

--- a/app/assets/stylesheets/profile.styl
+++ b/app/assets/stylesheets/profile.styl
@@ -74,6 +74,9 @@
           margin 0
           font-weight 300
 
+        h2.smallText
+          font-size 1.25em
+
         p
           font-weight 100
           font-size .8em

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ActiveRecord::Base
 
   validates_presence_of :username
   validates_uniqueness_of :username
+  validates :username, length: { maximum: 14,
+                                 too_long: "is too long. %{count} characters is the maximum allowed" }
 
   has_many :books
 


### PR DESCRIPTION
This addresses #195.

I thought a decent compromise solution might be to limit user names to a max of 14 characters and then have a smaller font size when they are over 9 characters, when displaying in the `profile`.

I also removed a width specification in the `nav` since it was also chopping off longer names. 