### PR TITLE
Remove phrase stub upon cancel

### DIFF
--- a/app/assets/javascripts/components/Dictionary.es6.jsx
+++ b/app/assets/javascripts/components/Dictionary.es6.jsx
@@ -177,6 +177,15 @@ class Dictionary extends React.Component {
       sourcePhrase: "",
       targetPhrase: ""
     });
+    if (this.state.isTargetInputActive && !this.state.targetPhrase) {
+      let phrasePairs = this.state.phrasePairs;
+      phrasePairs.splice(-1, 1);
+      this.setState({
+        phrasePairs,
+        isTargetInputActive: !this.state.isTargetInputActive,
+        isPhraseInputActive: true
+      });
+    }
     if (this.state.stream !== '') {
       this.onStopStream();
     }


### PR DESCRIPTION
Not sure if this is the desired behavior but the user can now cancel their phrase input after having saved the first (origin) word but before writing their second (target) word. It will clear out the first word and let the user start the phrase over. If the user clicks the cancel button again, they will be out of text-entry mode. #139 